### PR TITLE
chore(renovate): split github-actions updates by updateType

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,12 +5,32 @@
     "helpers:pinGitHubActionDigests",
     ":enablePreCommit"
   ],
+  "internalChecksFilter": "strict",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
   "automerge": true,
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {
+      "description": "Tagged action releases: cooldown, then automerge",
       "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "3 days",
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "description": "Major action bumps: cooldown, manual review",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "3 days",
       "automerge": false
+    },
+    {
+      "description": "Pure digest moves: no timestamp available, always review",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest", "pinDigest", "pin"],
+      "automerge": false,
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
Ports the Renovate GitHub Actions handling from [deviantintegral/flame_connect_ha#125](https://github.com/deviantintegral/flame_connect_ha/pull/125) to this repo, adapted to its existing `renovate.json`.

**Top-level:**
- `internalChecksFilter: strict` and `minimumReleaseAgeBehaviour: timestamp-required`, so an update with no resolvable release timestamp is blocked rather than automerged (the safe failure). (`helpers:pinGitHubActionDigests` was already present.)

**GitHub Actions split** (replaces the previous blanket `automerge: false` rule):

| Update type | Cooldown | Behavior |
| --- | --- | --- |
| `minor` / `patch` | 3 days | automerge via PR (waits for status checks) |
| `major` | 3 days | manual review |
| `digest` / `pinDigest` / `pin` | — | queued behind dependency dashboard approval |

The digest rule uses `dependencyDashboardApproval: true` so pure SHA moves (e.g. a force-pushed floating tag) wait for a manual tick instead of opening a trickle of unmergeable PRs. The 3-day cooldowns align with the project's global `minimumReleaseAge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cyyd7Wyozy9Squ9Zncq3iB)_